### PR TITLE
Fix initial layout

### DIFF
--- a/vulkano/src/command_buffer/synced/base.rs
+++ b/vulkano/src/command_buffer/synced/base.rs
@@ -638,26 +638,33 @@ impl<P> SyncCommandBufferBuilder<P> {
                     // transitions it out of an undefined state.
                     unsafe {
                         if !img.is_layout_initialized() {
-                            let mut b = UnsafeCommandBufferBuilderPipelineBarrier::new();
-                            b.add_image_memory_barrier(img,
-                                                        0 .. img.mipmap_levels(),
-                                                        0 .. img.dimensions().array_layers(),
-                                                        PipelineStages {
-                                                            bottom_of_pipe: true,
-                                                            ..PipelineStages::none()
-                                                        },
-                                                        AccessFlagBits::none(),
-                                                        stages,
-                                                        access,
-                                                        true,
-                                                        None,
-                                                        if img.preinitialized_layout() {
-                                                            ImageLayout::Preinitialized
-                                                        } else {
-                                                            ImageLayout::Undefined
-                                                        },
-                                                        initial_layout_requirement);
-                            self.inner.pipeline_barrier(&b);
+                            let init_layout = if img.preinitialized_layout() {
+                                ImageLayout::Preinitialized
+                            } else {
+                                ImageLayout::Undefined
+                            };
+                            if initial_layout_requirement != init_layout {
+                                let mut b = UnsafeCommandBufferBuilderPipelineBarrier::new();
+                                b.add_image_memory_barrier(img,
+                                                            0 .. img.mipmap_levels(),
+                                                            0 .. img.dimensions().array_layers(),
+                                                            PipelineStages {
+                                                                bottom_of_pipe: true,
+                                                                ..PipelineStages::none()
+                                                            },
+                                                            AccessFlagBits::none(),
+                                                            stages,
+                                                            access,
+                                                            true,
+                                                            None,
+                                                            if img.preinitialized_layout() {
+                                                                ImageLayout::Preinitialized
+                                                            } else {
+                                                                ImageLayout::Undefined
+                                                            },
+                                                            initial_layout_requirement);
+                                self.inner.pipeline_barrier(&b);
+                            }
                             img.layout_initialized();
                         }
                     }

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -502,6 +502,11 @@ unsafe impl<F, A> ImageAccess for AttachmentImage<F, A>
     unsafe fn layout_initialized(&self) {
        self.initialized.store(true, Ordering::SeqCst);
     }
+    
+    #[inline]
+    unsafe fn is_layout_initialized(&self) -> bool {
+       self.initialized.load(Ordering::SeqCst)
+    }
 }
 
 unsafe impl<F, A> ImageClearValue<F::ClearValue> for Arc<AttachmentImage<F, A>>

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -87,6 +87,11 @@ impl<W> SwapchainImage<W> {
     fn layout_initialized(&self) {
         self.swapchain.image_layout_initialized(self.image_offset);
     }
+    
+    #[inline]
+    unsafe fn is_layout_initialized(&self) -> bool {
+       self.swapchain.is_image_layout_initialized(self.image_offset)
+    }
 }
 
 unsafe impl<W> ImageAccess for SwapchainImage<W> {
@@ -129,6 +134,11 @@ unsafe impl<W> ImageAccess for SwapchainImage<W> {
     #[inline]
     unsafe fn layout_initialized(&self) {
         self.layout_initialized();
+    }
+    
+    #[inline]
+    unsafe fn is_layout_initialized(&self) -> bool{
+        self.is_layout_initialized()
     }
 
     #[inline]

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -67,6 +67,7 @@ pub struct UnsafeImage {
 
     // `vkDestroyImage` is called only if `needs_destruction` is true.
     needs_destruction: bool,
+    preinitialized_layout: bool,
 }
 
 impl UnsafeImage {
@@ -551,6 +552,7 @@ impl UnsafeImage {
             mipmaps: mipmaps,
             format_features: format_features,
             needs_destruction: true,
+            preinitialized_layout,
         };
 
         Ok((image, mem_reqs))
@@ -580,6 +582,7 @@ impl UnsafeImage {
             mipmaps: mipmaps,
             format_features: output.optimalTilingFeatures,
             needs_destruction: false, // TODO: pass as parameter
+            preinitialized_layout: false, // TODO: Maybe this should be passed in? 
         }
     }
 
@@ -777,6 +780,11 @@ impl UnsafeImage {
     #[inline]
     pub fn usage_input_attachment(&self) -> bool {
         (self.usage & vk::IMAGE_USAGE_INPUT_ATTACHMENT_BIT) != 0
+    }
+    
+    #[inline]
+    pub fn preinitialized_layout(&self) -> bool {
+        self.preinitialized_layout
     }
 }
 

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -106,6 +106,8 @@ pub unsafe trait ImageAccess {
     /// an image in an invalid layout. The same problem must be considered by the implementer
     /// of the method.
     unsafe fn layout_initialized(&self) {}
+    
+    unsafe fn is_layout_initialized(&self) -> bool {false}
 
     /// Returns the layout that the image has when it is first used in a primary command buffer.
     ///
@@ -296,6 +298,11 @@ unsafe impl<T> ImageAccess for T
     #[inline]
     unsafe fn layout_initialized(&self) {
         (**self).layout_initialized();
+    }
+    
+    #[inline]
+    unsafe fn is_layout_initialized(&self) -> bool {
+        (**self).is_layout_initialized()
     }
 }
 

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -109,6 +109,10 @@ pub unsafe trait ImageAccess {
     
     unsafe fn is_layout_initialized(&self) -> bool {false}
 
+    unsafe fn preinitialized_layout(&self) -> bool {
+        self.inner().image.preinitialized_layout()
+    }
+
     /// Returns the layout that the image has when it is first used in a primary command buffer.
     ///
     /// The first time you use an image in an `AutoCommandBufferBuilder`, vulkano will suppose that

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -566,6 +566,13 @@ impl <W> Swapchain<W> {
             image_entry.undefined_layout.store(false, Ordering::SeqCst);
         }
     }
+    
+    pub(crate) fn is_image_layout_initialized(&self, image_offset: usize) -> bool {
+        let image_entry = self.images.get(image_offset);
+        if let Some(ref image_entry) = image_entry {
+            image_entry.undefined_layout.load(Ordering::SeqCst)
+        } else { false } 
+    }
 }
 
 unsafe impl<W> VulkanObject for Swapchain<W> {


### PR DESCRIPTION
This fixes the layout issues we found with the validation layers.
It's still a bit rough and needs reviewing but it's testable right now.
To test:
```
VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_standard_validation
```
Then run your application.